### PR TITLE
MemoryClassLoader indexes the position of each file entry inside ZIP buffer.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,12 @@ configurations {
 
 dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.slf4j:slf4j-api:$slf4j_version"
 
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
 
-    testImplementation "org.slf4j:slf4j-api:$slf4j_version"
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
 
     testingLibraries "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/src/main/kotlin/com/r3/sgx/memory/MemoryClassLoader.kt
+++ b/src/main/kotlin/com/r3/sgx/memory/MemoryClassLoader.kt
@@ -1,29 +1,97 @@
 package com.r3.sgx.memory
 
+import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.net.URL
 import java.nio.ByteBuffer
+import java.nio.ByteOrder.LITTLE_ENDIAN
+import java.nio.charset.StandardCharsets.US_ASCII
+import java.nio.charset.StandardCharsets.UTF_8
 import java.security.CodeSigner
 import java.security.CodeSource
 import java.security.SecureClassLoader
 import java.util.Collections
 import java.util.Enumeration
-import java.util.zip.ZipEntry
-import java.util.zip.ZipEntry.STORED
+import java.util.zip.ZipException
 import java.util.zip.ZipInputStream
 
-open class MemoryClassLoader(urls: List<MemoryURL>, parent: ClassLoader?) : SecureClassLoader(parent) {
+open class MemoryClassLoader @Throws(IOException::class) constructor(
+    urls: List<MemoryURL>, parent: ClassLoader?
+) : SecureClassLoader(parent) {
+    private companion object {
+        private const val LOCAL_BLOCK_SIGNATURE = 0x04034b50
+        private const val DATA_DESCRIPTOR_SIGNATURE = 0x08074b50
+        private const val FLAGS_OFFSET = 6
+        private const val COMPRESSED_SIZE_OFFSET = 18
+        private const val BASE_DATA_DESCRIPTOR_SIZE = 12
+        private val logger = LoggerFactory.getLogger(MemoryClassLoader::class.java)
+    }
+
     @Suppress("unused")
+    @Throws(IOException::class)
     constructor(urls: List<MemoryURL>) : this(urls, ClassLoader.getSystemClassLoader())
 
     private val tablesOfContents = urls.associateWith(::getTableOfContents)
     private val urls = ArrayList(urls)
 
-    private fun getTableOfContents(url: MemoryURL): Set<String> {
-        return ZipInputStream(url.value.openStream()).use { zip ->
-            val contents = linkedSetOf<String>()
+    @Suppress("UsePropertyAccessSyntax")
+    @Throws(IOException::class)
+    private fun getTableOfContents(url: MemoryURL): Map<String, Int> {
+        val connection = url.value.openConnection()
+        return ZipInputStream(connection.getInputStream()).use { zip ->
+            val cursor = (connection.content as ByteBuffer).duplicate().order(LITTLE_ENDIAN)
+            val contents = linkedMapOf<String, Int>()
             while (true) {
                 val entry = zip.nextEntry ?: break
-                contents += entry.name
+                zip.closeEntry()
+
+                val position = cursor.position()
+                if (cursor.getInt(position) != LOCAL_BLOCK_SIGNATURE) {
+                    throw ZipException("Incorrect computed position for ${url.value.path}!/${entry.name}")
+                }
+
+                val entryDataSize = entry.compressedSize
+                if (entryDataSize > Int.MAX_VALUE) {
+                    throw ZipException("Zip entry ${entry.name} has invalid size $entryDataSize")
+                }
+
+                if (contents.putIfAbsent(entry.name, position) != null) {
+                    logger.warn("Duplicate entry {} in {}", entry.name, url.value)
+                }
+
+                val flagsField = cursor.getShort(position + FLAGS_OFFSET).toInt()
+                cursor.position(position + COMPRESSED_SIZE_OFFSET)
+                val compressedField = cursor.getInt()
+                val uncompressedField = cursor.getInt()
+                val nameLength = cursor.getShort().toUShort().toInt()
+                val extraLength = cursor.getShort().toUShort().toInt()
+
+                // Check that we're indexing the correct entry.
+                val nameBytes = ByteArray(nameLength)
+                cursor.get(nameBytes)
+                val name = String(nameBytes, if (flagsField and 0x800 != 0) UTF_8 else US_ASCII)
+                if (name != entry.name) {
+                    throw ZipException("Expected ${entry.name} but found $name")
+                }
+
+                // Advance past all headers and the data itself.
+                cursor.position(cursor.position() + extraLength + entryDataSize.toInt())
+
+                // Check for a data descriptor trailing the data.
+                if (flagsField and 0x08 != 0 && entry.size > 0) {
+                    var dataDescriptorSize = BASE_DATA_DESCRIPTOR_SIZE
+                    val current = cursor.position()
+                    val signature = cursor.getInt(current)
+                    if (signature == DATA_DESCRIPTOR_SIGNATURE) {
+                        // This signature is optional.
+                        dataDescriptorSize += Int.SIZE_BYTES
+                    }
+                    if (compressedField == -1 || uncompressedField == -1) {
+                        // This is a Zip64 file entry.
+                        dataDescriptorSize += (Long.SIZE_BYTES - Int.SIZE_BITS) * 2
+                    }
+                    cursor.position(current + dataDescriptorSize)
+                }
             }
             contents
         }
@@ -33,10 +101,10 @@ open class MemoryClassLoader(urls: List<MemoryURL>, parent: ClassLoader?) : Secu
         return urls.map(MemoryURL::value).toTypedArray()
     }
 
-    private fun findHost(resourceName: String?): MemoryURL? {
+    private fun findResourceLocation(resourceName: String?): Pair<MemoryURL, Int>? {
         tablesOfContents.forEach { (host, tableOfContents) ->
-            if (resourceName in tableOfContents) {
-                return host
+            tableOfContents[resourceName]?.also { position ->
+                return host to position
             }
         }
         return null
@@ -45,20 +113,13 @@ open class MemoryClassLoader(urls: List<MemoryURL>, parent: ClassLoader?) : Secu
     @Throws(ClassNotFoundException::class)
     final override fun findClass(name: String): Class<*>? {
         val resourceName = name.replace('.', '/') + ".class"
-        findHost(resourceName)?.also { host ->
+        findResourceLocation(resourceName)?.also { (host, position) ->
             val connection = host.value.openConnection()
             ZipInputStream(connection.getInputStream()).use { zip ->
-                while (true) {
-                    val entry = zip.nextEntry ?: break
+                (connection.content as ByteBuffer).position(position)
+                zip.nextEntry?.also { entry ->
                     if (resourceName == entry.name) {
-                        val byteCode = if (entry.isUncompressed && connection.content is ByteBuffer) {
-                            (connection.content as ByteBuffer).slice().apply {
-                                // Zero-copy optimisation for uncompressed data.
-                                limit(entry.size.toInt())
-                            }
-                        } else {
-                            ByteBuffer.wrap(zip.readBytes())
-                        }
+                        val byteCode = ByteBuffer.wrap(zip.readBytes())
                         return defineClass(name, byteCode, host)
                     }
                 }
@@ -84,7 +145,7 @@ open class MemoryClassLoader(urls: List<MemoryURL>, parent: ClassLoader?) : Secu
     }
 
     final override fun findResource(name: String?): URL? {
-        return findHost(name)?.let { host ->
+        return findResourceLocation(name)?.let { (host, _) ->
             createResource(host.value, name)
         }
     }
@@ -94,6 +155,4 @@ open class MemoryClassLoader(urls: List<MemoryURL>, parent: ClassLoader?) : Secu
             host.takeIf { name in tableOfContents }?.let { createResource(it.value, name) }
         }.let(Collections::enumeration)
     }
-
-    private val ZipEntry.isUncompressed: Boolean get() = method == STORED && size > 0
 }

--- a/src/test/kotlin/com/r3/sgx/memory/DummyJar.kt
+++ b/src/test/kotlin/com/r3/sgx/memory/DummyJar.kt
@@ -3,6 +3,7 @@ package com.r3.sgx.memory
 import org.assertj.core.api.Assertions.assertThat
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.Random
 import java.util.jar.Attributes
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
@@ -32,6 +33,10 @@ class DummyJar(
     }
 
     private companion object {
+        private const val DATA_SIZE = 1536
+
+        private fun arrayOfJunk() = ByteArray(DATA_SIZE).also(Random()::nextBytes)
+
         private fun uncompressed(name: String, data: ByteArray) = ZipEntry(name).apply {
             method = ZipEntry.STORED
             compressedSize = data.size.toLong()
@@ -79,6 +84,10 @@ class DummyJar(
 
             // One directory entry (stored)
             jar.putNextEntry(directoryOf(testClass))
+
+            // One compressed non-class file
+            jar.putNextEntry(compressed("binary.dat"))
+            jar.write(arrayOfJunk())
 
             // One compressed class file
             jar.putNextEntry(compressed(testClass.resourceName))


### PR DESCRIPTION
Compute the indices of each ZIP entry inside the `ByteBuffer` so that we can jump directly to them without first deflating everything that precedes them.